### PR TITLE
Add Windows CI build and release workflows; make Windows build scripts CI-friendly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set build version
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          choco install lazarus -y
+          choco install wixtoolset -y
+
+      - name: Build 64-bit binary
+        shell: cmd
+        run: build.cmd
+
+      - name: Build 32-bit binary
+        shell: cmd
+        run: build32.cmd
+
+      - name: Build installers (x64)
+        shell: cmd
+        env:
+          BUILD_PORTABLE: 0
+        run: installer\build.cmd x64 %VERSION%
+
+      - name: Build installers (x86 + portable)
+        shell: cmd
+        env:
+          BUILD_PORTABLE: 1
+        run: installer\build.cmd x86 %VERSION%
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            installer/*.msi
+            installer/*.zip
+
+  release:
+    needs: build
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag_name: ${{ github.ref_name }}
+      artifact_name: build-artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,24 @@
 name: Create Release
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      artifact_name:
+        required: false
+        type: string
+        default: build-artifacts
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to create
+        required: true
+        type: string
+      artifact_name:
+        description: Artifact name to attach
+        required: false
+        default: build-artifacts
 
 permissions:
   contents: write
@@ -47,9 +63,19 @@ jobs:
       - name: Show generated changelog
         run: cat CHANGELOG.md
 
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name || github.event.inputs.artifact_name }}
+          path: dist
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ inputs.tag_name || github.event.inputs.tag_name }}
           body_path: CHANGELOG.md
           draft: true
           prerelease: false
+          files: |
+            dist/**/*.msi
+            dist/**/*.zip

--- a/build.cmd
+++ b/build.cmd
@@ -2,35 +2,48 @@
 setlocal
 
 ::Build Lazarus project "padxml" using lazbuild
-SET PROJECT_PATH=padxml.lpi
-SET BUILD_MODE=Release
+SET "PROJECT_PATH=padxml.lpi"
+SET "BUILD_MODE=Release"
+
+SET "LAZARUS_DIR=%LAZARUS_DIR%"
+for %%D in ("%LAZARUS_DIR%" "C:\Lazarus" "C:\lazarus") do (
+    if exist "%%~D\lazbuild.exe" (
+        SET "LAZARUS_DIR=%%~D"
+    )
+)
+
+if not exist "%LAZARUS_DIR%\lazbuild.exe" (
+    echo Lazarus not found. Set LAZARUS_DIR or install Lazarus.
+    exit /b 1
+)
+
+SET "LAZBUILD=%LAZARUS_DIR%\lazbuild.exe"
 
 echo Building project: %PROJECT_PATH%
-"C:\Lazarus\lazbuild.exe" %PROJECT_PATH% --build-mode=%BUILD_MODE%
+"%LAZBUILD%" %PROJECT_PATH% --build-mode=%BUILD_MODE%
 
 IF %ERRORLEVEL% NEQ 0 (
     echo Build failed!
-    pause
     exit /b %ERRORLEVEL%
 )
 
 echo Build completed successfully
 
 ::Certificate settings
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=%~dp0installer\AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
+SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+SET "CERTFILE=%~dp0installer\AlexanderT.pfx"
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
 ::Sign the executable in the same folder
-if exist "padxml.exe" (
+if exist "padxml.exe" if exist "%SIGNTOOL%" if exist "%CERTFILE%" (
     echo Signing executable...
-    %SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml.exe"
+    "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml.exe"
     IF %ERRORLEVEL% EQU 0 (
         echo Signing completed successfully
     ) else (
         echo Signing failed
     )
 ) else (
-    echo Executable not found: padxml.exe
+    echo Skipping signing (missing executable, cert, or signtool).
 )

--- a/build32.cmd
+++ b/build32.cmd
@@ -2,11 +2,36 @@
 setlocal
 
 ::Build 32-bit Lazarus project "padxml" using lazbuild
-SET PROJECT_PATH=padxml.lpi
-SET BUILD_MODE=Release
+SET "PROJECT_PATH=padxml.lpi"
+SET "BUILD_MODE=Release"
+
+SET "LAZARUS_DIR=%LAZARUS_DIR%"
+for %%D in ("%LAZARUS_DIR%" "C:\Lazarus" "C:\lazarus") do (
+    if exist "%%~D\lazbuild.exe" (
+        SET "LAZARUS_DIR=%%~D"
+    )
+)
+
+if not exist "%LAZARUS_DIR%\lazbuild.exe" (
+    echo Lazarus not found. Set LAZARUS_DIR or install Lazarus.
+    exit /b 1
+)
+
+SET "LAZBUILD=%LAZARUS_DIR%\lazbuild.exe"
 
 ::Path to 32-bit FPC compiler
-SET FPC32="C:\lazarus\fpc\3.2.2\bin\i386-win32\fpc.exe"
+SET "FPC32=%FPC32_PATH%"
+if not exist "%FPC32%" (
+    for /d %%F in ("%LAZARUS_DIR%\fpc\*") do (
+        if exist "%%~F\bin\i386-win32\fpc.exe" (
+            SET "FPC32=%%~F\bin\i386-win32\fpc.exe"
+        )
+    )
+)
+if not exist "%FPC32%" (
+    echo 32-bit FPC compiler not found. Set FPC32_PATH.
+    exit /b 1
+)
 
 ::Rename existing 64-bit exe to padxml64.exe to avoid overwriting
 if exist "padxml.exe" (
@@ -15,13 +40,12 @@ if exist "padxml.exe" (
 )
 
 echo Building 32-bit project: %PROJECT_PATH%
-"C:\Lazarus\lazbuild.exe" %PROJECT_PATH% --cpu=i386 --ws=win32 --build-mode=%BUILD_MODE% --compiler=%FPC32%
+"%LAZBUILD%" %PROJECT_PATH% --cpu=i386 --ws=win32 --build-mode=%BUILD_MODE% --compiler=%FPC32%
 
 IF %ERRORLEVEL% NEQ 0 (
     echo 32-bit build failed!
     ::Restore 64-bit exe back
     if exist "padxml64.exe" ren "padxml64.exe" "padxml.exe"
-    pause
     exit /b %ERRORLEVEL%
 )
 
@@ -45,20 +69,20 @@ echo 32-bit build completed successfully
 timeout /t 2 /nobreak >nul
 
 ::Certificate settings
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=%~dp0installer\AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
+SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+SET "CERTFILE=%~dp0installer\AlexanderT.pfx"
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
 ::Sign the 32-bit executable
-if exist "padxml32.exe" (
+if exist "padxml32.exe" if exist "%SIGNTOOL%" if exist "%CERTFILE%" (
     echo Signing 32-bit executable...
-    %SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml32.exe"
+    "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml32.exe"
     IF %ERRORLEVEL% EQU 0 (
         echo Signing completed successfully
     ) else (
         echo Signing failed
     )
 ) else (
-    echo Executable not found: padxml32.exe
+    echo Skipping signing (missing executable, cert, or signtool).
 )

--- a/installer/build.cmd
+++ b/installer/build.cmd
@@ -2,8 +2,14 @@
 setlocal
 
 :: Define paths
-SET "SOURCE_DIR=E:\padxml\installer"
-SET "VERSION=1.0.0"
+SET "SOURCE_DIR=%~dp0"
+SET "VERSION=%VERSION%"
+IF "%~2" NEQ "" (
+    SET "VERSION=%~2"
+)
+IF "%VERSION%"=="" (
+    SET "VERSION=0.0.0"
+)
 
 :: Check if platform parameter is provided
 IF "%1"=="" (
@@ -17,7 +23,6 @@ IF NOT "%PLATFORM%"=="x64" IF NOT "%PLATFORM%"=="x86" (
     echo Error: Invalid platform parameter. Use x64 or x86.
     echo Example: %0 x64
     echo Example: %0 x86
-    pause
     exit /b 1
 )
 
@@ -45,31 +50,37 @@ echo Cleanup completed.
 echo.
 
 :: --- Sign installers ---
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
+SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+SET "CERTFILE=%SOURCE_DIR%AlexanderT.pfx"
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
-echo Signing MSI files...
-%SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%.msi"
-IF %ERRORLEVEL% EQU 0 (
-    echo Signing of padxml-%VERSION%-%PLATFORM%.msi completed successfully
-) else (
-    echo Signing failed for padxml-%VERSION%-%PLATFORM%.msi
-)
+if exist "%SIGNTOOL%" if exist "%CERTFILE%" (
+    echo Signing MSI files...
+    "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%.msi"
+    IF %ERRORLEVEL% EQU 0 (
+        echo Signing of padxml-%VERSION%-%PLATFORM%.msi completed successfully
+    ) else (
+        echo Signing failed for padxml-%VERSION%-%PLATFORM%.msi
+    )
 
-%SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%-allusers.msi"
-IF %ERRORLEVEL% EQU 0 (
-    echo Signing of padxml-%VERSION%-%PLATFORM%-allusers.msi completed successfully
+    "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%-allusers.msi"
+    IF %ERRORLEVEL% EQU 0 (
+        echo Signing of padxml-%VERSION%-%PLATFORM%-allusers.msi completed successfully
+    ) else (
+        echo Signing failed for padxml-%VERSION%-%PLATFORM%-allusers.msi
+    )
 ) else (
-    echo Signing failed for padxml-%VERSION%-%PLATFORM%-allusers.msi
+    echo Skipping signing (missing cert or signtool).
 )
 
 :: --- Portable ---
-powershell -Command ^
-"Compress-Archive ^
- -Force ^
- -Path ..\padxml.exe,..\padxml32.exe, .\form_settings.json ^
- -DestinationPath padxml-%VERSION%-x86-x64-portable.zip"
+if "%BUILD_PORTABLE%"=="1" (
+    powershell -Command ^
+    "Compress-Archive ^
+     -Force ^
+     -Path ..\padxml.exe,..\padxml32.exe, .\form_settings.json ^
+     -DestinationPath padxml-%VERSION%-x86-x64-portable.zip"
+)
 
 echo Build and signing completed successfully!


### PR DESCRIPTION
### Motivation
- Add a Windows CI pipeline that builds Lazarus binaries, produces MSI and portable ZIP artifacts, and attaches them to a draft GitHub release created from a tag. 
- Make existing Windows build scripts usable in CI by making Lazarus/FPC paths configurable and making signing/portable packaging conditional. 
- Reuse the existing release workflow from the build workflow so artifacts created by CI are attached to a draft release without creating real releases automatically.

### Description
- Add `.github/workflows/build.yml` which triggers on pushed tags `v*`, installs `lazarus` and `wixtoolset` via Chocolatey, runs `build.cmd`/`build32.cmd`, builds installers for x64/x86, uploads artifacts as `build-artifacts`, and calls the updated release workflow. 
- Update `.github/workflows/create-release.yml` to be a reusable `workflow_call` and `workflow_dispatch` with inputs `tag_name` and `artifact_name`, to download artifacts and attach `dist/**/*.msi` and `dist/**/*.zip` to a draft release. 
- Make `build.cmd` auto-detect `lazbuild.exe` via `LAZARUS_DIR` or common install locations, expose `LAZBUILD` and use it to build, and make signing conditional on presence of `signtool` and certificate. 
- Make `build32.cmd` auto-detect `lazbuild.exe` and a 32-bit FPC compiler via `FPC32_PATH` or the Lazarus `fpc` directory, use the detected compiler for the 32-bit build, and make signing conditional. 
- Update `installer/build.cmd` to use `%~dp0` for `SOURCE_DIR`, accept a version parameter or read `VERSION` env, avoid interactive `pause`, make signing conditional, and support conditional portable ZIP creation via `BUILD_PORTABLE`. 

### Testing
- No automated tests were executed as part of these edits; the changes are CI workflow and script updates that will be exercised when the pipeline runs on a pushed tag `v*`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e20a9648833396b79e9fa60b4d70)