### PR TITLE
Prefer local PFX or CERT_PFX secret for signing and expose secret in Windows workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      CERT_PFX: ${{ secrets.CERT_PFX }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set build version
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}" -replace '^v', ''
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          choco install lazarus -y
+          choco install wixtoolset -y
+
+      - name: Build 64-bit binary
+        shell: cmd
+        run: build.cmd
+
+      - name: Build 32-bit binary
+        shell: cmd
+        run: build32.cmd
+
+      - name: Build installers (x64)
+        shell: cmd
+        env:
+          BUILD_PORTABLE: 0
+        run: installer\build.cmd x64 %VERSION%
+
+      - name: Build installers (x86 + portable)
+        shell: cmd
+        env:
+          BUILD_PORTABLE: 1
+        run: installer\build.cmd x86 %VERSION%
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            installer/*.msi
+            installer/*.zip
+
+  release:
+    needs: build
+    uses: ./.github/workflows/create-release.yml
+    with:
+      tag_name: ${{ github.ref_name }}
+      artifact_name: build-artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,24 @@
 name: Create Release
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      artifact_name:
+        required: false
+        type: string
+        default: build-artifacts
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to create
+        required: true
+        type: string
+      artifact_name:
+        description: Artifact name to attach
+        required: false
+        default: build-artifacts
 
 permissions:
   contents: write
@@ -47,9 +63,19 @@ jobs:
       - name: Show generated changelog
         run: cat CHANGELOG.md
 
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name || github.event.inputs.artifact_name }}
+          path: dist
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ inputs.tag_name || github.event.inputs.tag_name }}
           body_path: CHANGELOG.md
           draft: true
           prerelease: false
+          files: |
+            dist/**/*.msi
+            dist/**/*.zip

--- a/build.cmd
+++ b/build.cmd
@@ -2,35 +2,73 @@
 setlocal
 
 ::Build Lazarus project "padxml" using lazbuild
-SET PROJECT_PATH=padxml.lpi
-SET BUILD_MODE=Release
+SET "PROJECT_PATH=padxml.lpi"
+SET "BUILD_MODE=Release"
+
+SET "LAZARUS_DIR=%LAZARUS_DIR%"
+for %%D in ("%LAZARUS_DIR%" "C:\Lazarus" "C:\lazarus") do (
+    if exist "%%~D\lazbuild.exe" (
+        SET "LAZARUS_DIR=%%~D"
+    )
+)
+
+if not exist "%LAZARUS_DIR%\lazbuild.exe" (
+    echo Lazarus not found. Set LAZARUS_DIR or install Lazarus.
+    exit /b 1
+)
+
+SET "LAZBUILD=%LAZARUS_DIR%\lazbuild.exe"
 
 echo Building project: %PROJECT_PATH%
-"C:\Lazarus\lazbuild.exe" %PROJECT_PATH% --build-mode=%BUILD_MODE%
+"%LAZBUILD%" %PROJECT_PATH% --build-mode=%BUILD_MODE%
 
 IF %ERRORLEVEL% NEQ 0 (
     echo Build failed!
-    pause
     exit /b %ERRORLEVEL%
 )
 
 echo Build completed successfully
 
-::Certificate settings
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=%~dp0installer\AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
+::Certificate settings (optional)
+IF "%SIGNTOOL%"=="" (
+    SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+)
+IF "%CERTFILE%"=="" (
+    IF EXIST "%CD%\installer\AlexanderT.pfx" (
+        SET "CERTFILE=%CD%\installer\AlexanderT.pfx"
+    ) ELSE (
+        IF NOT "%CERT_PFX%"=="" (
+            SET "CERTFILE=%TEMP%\padxml-cert.pfx"
+            powershell -NoProfile -Command "[IO.File]::WriteAllBytes('%TEMP%\\padxml-cert.pfx',[Convert]::FromBase64String($env:CERT_PFX))"
+        ) ELSE (
+            SET "CERTFILE="
+        )
+    )
+)
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
 ::Sign the executable in the same folder
 if exist "padxml.exe" (
-    echo Signing executable...
-    %SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml.exe"
-    IF %ERRORLEVEL% EQU 0 (
-        echo Signing completed successfully
+    if not "%CERTFILE%"=="" (
+        if exist "%CERTFILE%" (
+            if exist "%SIGNTOOL%" (
+                echo Signing executable...
+                "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml.exe"
+                IF %ERRORLEVEL% EQU 0 (
+                    echo Signing completed successfully
+                ) else (
+                    echo Signing failed
+                )
+            ) else (
+                echo Skipping signing: signtool not found.
+            )
+        ) else (
+            echo Skipping signing: cert file not found.
+        )
     ) else (
-        echo Signing failed
+        echo Skipping signing: CERTFILE not set.
     )
 ) else (
-    echo Executable not found: padxml.exe
+    echo Skipping signing: missing executable.
 )

--- a/build32.cmd
+++ b/build32.cmd
@@ -2,11 +2,36 @@
 setlocal
 
 ::Build 32-bit Lazarus project "padxml" using lazbuild
-SET PROJECT_PATH=padxml.lpi
-SET BUILD_MODE=Release
+SET "PROJECT_PATH=padxml.lpi"
+SET "BUILD_MODE=Release"
+
+SET "LAZARUS_DIR=%LAZARUS_DIR%"
+for %%D in ("%LAZARUS_DIR%" "C:\Lazarus" "C:\lazarus") do (
+    if exist "%%~D\lazbuild.exe" (
+        SET "LAZARUS_DIR=%%~D"
+    )
+)
+
+if not exist "%LAZARUS_DIR%\lazbuild.exe" (
+    echo Lazarus not found. Set LAZARUS_DIR or install Lazarus.
+    exit /b 1
+)
+
+SET "LAZBUILD=%LAZARUS_DIR%\lazbuild.exe"
 
 ::Path to 32-bit FPC compiler
-SET FPC32="C:\lazarus\fpc\3.2.2\bin\i386-win32\fpc.exe"
+SET "FPC32=%FPC32_PATH%"
+if not exist "%FPC32%" (
+    for /d %%F in ("%LAZARUS_DIR%\fpc\*") do (
+        if exist "%%~F\bin\i386-win32\fpc.exe" (
+            SET "FPC32=%%~F\bin\i386-win32\fpc.exe"
+        )
+    )
+)
+if not exist "%FPC32%" (
+    echo 32-bit FPC compiler not found. Set FPC32_PATH.
+    exit /b 1
+)
 
 ::Rename existing 64-bit exe to padxml64.exe to avoid overwriting
 if exist "padxml.exe" (
@@ -15,13 +40,12 @@ if exist "padxml.exe" (
 )
 
 echo Building 32-bit project: %PROJECT_PATH%
-"C:\Lazarus\lazbuild.exe" %PROJECT_PATH% --cpu=i386 --ws=win32 --build-mode=%BUILD_MODE% --compiler=%FPC32%
+"%LAZBUILD%" %PROJECT_PATH% --cpu=i386 --ws=win32 --build-mode=%BUILD_MODE% --compiler=%FPC32%
 
 IF %ERRORLEVEL% NEQ 0 (
     echo 32-bit build failed!
     ::Restore 64-bit exe back
     if exist "padxml64.exe" ren "padxml64.exe" "padxml.exe"
-    pause
     exit /b %ERRORLEVEL%
 )
 
@@ -44,21 +68,46 @@ echo 32-bit build completed successfully
 ::Wait 2 seconds to ensure file is free
 timeout /t 2 /nobreak >nul
 
-::Certificate settings
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=%~dp0installer\AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
+::Certificate settings (optional)
+IF "%SIGNTOOL%"=="" (
+    SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+)
+IF "%CERTFILE%"=="" (
+    IF EXIST "%CD%\installer\AlexanderT.pfx" (
+        SET "CERTFILE=%CD%\installer\AlexanderT.pfx"
+    ) ELSE (
+        IF NOT "%CERT_PFX%"=="" (
+            SET "CERTFILE=%TEMP%\padxml-cert.pfx"
+            powershell -NoProfile -Command "[IO.File]::WriteAllBytes('%TEMP%\\padxml-cert.pfx',[Convert]::FromBase64String($env:CERT_PFX))"
+        ) ELSE (
+            SET "CERTFILE="
+        )
+    )
+)
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
 ::Sign the 32-bit executable
 if exist "padxml32.exe" (
-    echo Signing 32-bit executable...
-    %SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml32.exe"
-    IF %ERRORLEVEL% EQU 0 (
-        echo Signing completed successfully
+    if not "%CERTFILE%"=="" (
+        if exist "%CERTFILE%" (
+            if exist "%SIGNTOOL%" (
+                echo Signing 32-bit executable...
+                "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "padxml32.exe"
+                IF %ERRORLEVEL% EQU 0 (
+                    echo Signing completed successfully
+                ) else (
+                    echo Signing failed
+                )
+            ) else (
+                echo Skipping signing: signtool not found.
+            )
+        ) else (
+            echo Skipping signing: cert file not found.
+        )
     ) else (
-        echo Signing failed
+        echo Skipping signing: CERTFILE not set.
     )
 ) else (
-    echo Executable not found: padxml32.exe
+    echo Skipping signing: missing executable.
 )

--- a/installer/build.cmd
+++ b/installer/build.cmd
@@ -2,8 +2,14 @@
 setlocal
 
 :: Define paths
-SET "SOURCE_DIR=E:\padxml\installer"
-SET "VERSION=1.0.0"
+SET "SOURCE_DIR=%~dp0"
+SET "VERSION=%VERSION%"
+IF "%~2" NEQ "" (
+    SET "VERSION=%~2"
+)
+IF "%VERSION%"=="" (
+    SET "VERSION=0.0.0"
+)
 
 :: Check if platform parameter is provided
 IF "%1"=="" (
@@ -17,7 +23,6 @@ IF NOT "%PLATFORM%"=="x64" IF NOT "%PLATFORM%"=="x86" (
     echo Error: Invalid platform parameter. Use x64 or x86.
     echo Example: %0 x64
     echo Example: %0 x86
-    pause
     exit /b 1
 )
 
@@ -45,31 +50,58 @@ echo Cleanup completed.
 echo.
 
 :: --- Sign installers ---
-SET SIGNTOOL="C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
-SET CERTFILE=AlexanderT.pfx
-SET CERTPASS=1234
-SET TIMESTAMP_URL=http://timestamp.digicert.com
-
-echo Signing MSI files...
-%SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%.msi"
-IF %ERRORLEVEL% EQU 0 (
-    echo Signing of padxml-%VERSION%-%PLATFORM%.msi completed successfully
-) else (
-    echo Signing failed for padxml-%VERSION%-%PLATFORM%.msi
+IF "%SIGNTOOL%"=="" (
+    SET "SIGNTOOL=C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
 )
+IF "%CERTFILE%"=="" (
+    IF EXIST "%CD%\installer\AlexanderT.pfx" (
+        SET "CERTFILE=%CD%\installer\AlexanderT.pfx"
+    ) ELSE (
+        IF NOT "%CERT_PFX%"=="" (
+            SET "CERTFILE=%TEMP%\padxml-cert.pfx"
+            powershell -NoProfile -Command "[IO.File]::WriteAllBytes('%TEMP%\\padxml-cert.pfx',[Convert]::FromBase64String($env:CERT_PFX))"
+        ) ELSE (
+            SET "CERTFILE="
+        )
+    )
+)
+SET "CERTPASS=1234"
+SET "TIMESTAMP_URL=http://timestamp.digicert.com"
 
-%SIGNTOOL% sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%-allusers.msi"
-IF %ERRORLEVEL% EQU 0 (
-    echo Signing of padxml-%VERSION%-%PLATFORM%-allusers.msi completed successfully
+if not "%CERTFILE%"=="" (
+    if exist "%CERTFILE%" (
+        if exist "%SIGNTOOL%" (
+            echo Signing MSI files...
+            "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%.msi"
+            IF %ERRORLEVEL% EQU 0 (
+                echo Signing of padxml-%VERSION%-%PLATFORM%.msi completed successfully
+            ) else (
+                echo Signing failed for padxml-%VERSION%-%PLATFORM%.msi
+            )
+
+            "%SIGNTOOL%" sign /f "%CERTFILE%" /p "%CERTPASS%" /fd SHA256 /tr %TIMESTAMP_URL% /td SHA256 "%SOURCE_DIR%\padxml-%VERSION%-%PLATFORM%-allusers.msi"
+            IF %ERRORLEVEL% EQU 0 (
+                echo Signing of padxml-%VERSION%-%PLATFORM%-allusers.msi completed successfully
+            ) else (
+                echo Signing failed for padxml-%VERSION%-%PLATFORM%-allusers.msi
+            )
+        ) else (
+            echo Skipping signing: signtool not found.
+        )
+    ) else (
+        echo Skipping signing: cert file not found.
+    )
 ) else (
-    echo Signing failed for padxml-%VERSION%-%PLATFORM%-allusers.msi
+    echo Skipping signing: CERTFILE not set.
 )
 
 :: --- Portable ---
-powershell -Command ^
-"Compress-Archive ^
- -Force ^
- -Path ..\padxml.exe,..\padxml32.exe, .\form_settings.json ^
- -DestinationPath padxml-%VERSION%-x86-x64-portable.zip"
+if "%BUILD_PORTABLE%"=="1" (
+    powershell -Command ^
+    "Compress-Archive ^
+     -Force ^
+     -Path ..\padxml.exe,..\padxml32.exe, .\form_settings.json ^
+     -DestinationPath padxml-%VERSION%-x86-x64-portable.zip"
+)
 
 echo Build and signing completed successfully!


### PR DESCRIPTION
### Motivation
- Allow signing to use a local PFX during local builds and fall back to a CI secret when the file is not present, so CI can sign artifacts without storing the PFX in the repo. 
- Improve robustness of the Windows build scripts by making tool and compiler paths configurable and handling missing tools/certificates gracefully.

### Description
- Updated `build.cmd`, `build32.cmd`, and `installer/build.cmd` to prefer `%CD%\installer\AlexanderT.pfx` when present and otherwise decode the `CERT_PFX` environment secret (base64) into a temporary PFX file for signing. 
- Added checks so signing is skipped with clear colon-separated messages when `signtool`, the cert file, or the executable are missing, and retained exit-path behavior when builds fail. 
- Made Lazarus/lazbuild and 32-bit FPC detection more flexible by probing common locations and honoring `LAZARUS_DIR` / `FPC32_PATH`, and switched to using the discovered `LAZBUILD` path. 
- Updated `.github/workflows/build.yml` to pass the `CERT_PFX` secret into the Windows build job via `env: CERT_PFX: ${{ secrets.CERT_PFX }}`. 
- Adjusted `create-release.yml` to use `workflow_call`/inputs and to download artifacts into the release workflow before attaching them to the release.

### Testing
- No automated tests were run for these script and workflow changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e20a9648833396b79e9fa60b4d70)